### PR TITLE
Fix compatibility with 2024.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginName=intellij-kdl
 pluginVersion=2.1.0
 
 pluginSinceBuild=223
-pluginUntilBuild=232.*
+pluginUntilBuild=300.*
 
 platformType=IC
 platformVersion=2022.3


### PR DESCRIPTION
Both v2.0.0 and v2.1.0 are not working with IntelliJ 2024.1

This change allowed me to build and install the plugin locally